### PR TITLE
CAW-479: Add javascript and css resources when the views are loaded.

### DIFF
--- a/stanford_faq.module
+++ b/stanford_faq.module
@@ -10,7 +10,6 @@ include_once 'stanford_faq.features.inc';
  * Implements hook_preprocess().
  */
 function stanford_faq_preprocess_page(&$vars) {
-  $current_path = current_path();
   $arg0 = arg(0);
 
   if ($arg0 == "faq") {

--- a/stanford_faq.module
+++ b/stanford_faq.module
@@ -7,7 +7,7 @@
 include_once 'stanford_faq.features.inc';
 
 /**
- * Implements hook_preprocess().
+ * Implements hook_preprocess_HOOK().
  */
 function stanford_faq_preprocess_page(&$vars) {
   $current_path = current_path();

--- a/stanford_faq.module
+++ b/stanford_faq.module
@@ -7,11 +7,34 @@
 include_once 'stanford_faq.features.inc';
 
 /**
+ * Implements hook_preprocess().
+ */
+function stanford_faq_preprocess_page(&$vars) {
+  $current_path = current_path();
+  $arg0 = arg(0);
+
+  if ($arg0 == "faq") {
+    drupal_add_js(drupal_get_path("module", "stanford_faq") . "/js/stanford_faq.js");
+    drupal_add_css(drupal_get_path("module", "stanford_faq") . "/css/stanford_faq.css");
+  }
+
+}
+
+/**
  * Implements hook_views_pre_render
  */
 function stanford_faq_views_pre_render(&$view) {
+
+  $valid = array(
+    'stanford_related_show_hide_faqs_block',
+    'stanford_related_faqs_block',
+    'stanford_show_hide_faq_hierarchy',
+  );
+
   // Add aria help to show hide view for faqs.
-  if ($view->name == "stanford_show_hide_faq_hierarchy") {
+  if (in_array($view->name, $valid)) {
     drupal_add_js(drupal_get_path("module", "stanford_faq") . "/js/stanford_faq.js");
+    drupal_add_css(drupal_get_path("module", "stanford_faq") . "/css/stanford_faq.css");
   }
+
 }


### PR DESCRIPTION
Added hooks for adding Megans css to the faq pages. I have added the preprocess page function on top of the pre_render function as often we clone the views to a different name before making changes.
